### PR TITLE
SPDO-16 drawer refactor

### DIFF
--- a/lib/drawer_widget.dart
+++ b/lib/drawer_widget.dart
@@ -1,0 +1,249 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:package_info/package_info.dart';
+
+import 'image_picker_utils.dart';
+import 'settings.dart';
+
+@immutable
+class DrawerWidget extends StatefulWidget {
+  @override
+  _DrawerWidgetState createState() => _DrawerWidgetState();
+}
+
+class _DrawerWidgetState extends State<DrawerWidget> {
+  final String displayMetric = "km/h";
+  final String displayImperial = "MPH";
+  String unitsSubtitle = "MPH | km/h";
+
+  PackageInfo? packageInfo;
+  late Settings settings;
+
+  final sliderColor = Color(0xFFF5F5F5);
+  final scaffoldKey = GlobalKey<ScaffoldState>();
+  final iconSize = 24.0;
+
+  @override
+  void initState() {
+    super.initState();
+    loadPreferences();
+    loadPlatformInfo();
+  }
+
+  void loadPreferences() async {
+    settings = await Settings.getInstance();
+  }
+
+  void loadPlatformInfo() {
+    PackageInfo.fromPlatform().then((PackageInfo value) {
+      setState(() {
+        packageInfo = value;
+      });
+    });
+  }
+
+  Widget backgroundChooserWidget() {
+    return ListTile(
+      title: Row(children: [
+        Icon(Icons.add_a_photo),
+        Spacer(),
+        IconButton(
+          icon: Icon(Icons.clear),
+          onPressed: () => ImagePickerUtils.clearImage(),
+        ),
+      ]),
+      onTap: () => ImagePickerUtils.browseForImage(),
+    );
+  }
+
+  Widget unitSelectionWidget() {
+    return SwitchListTile(
+      value: settings.metric,
+      onChanged: (newValue) => setState(() {
+        settings.metric = newValue;
+      }),
+      title: Text(unitsSubtitle, style: TextStyle(fontWeight: FontWeight.bold)),
+      tileColor: sliderColor,
+      activeColor: sliderColor,
+      activeTrackColor: Colors.grey,
+      inactiveTrackColor: Colors.grey,
+      dense: false,
+      controlAffinity: ListTileControlAffinity.trailing,
+    );
+  }
+
+  Widget digitalSpeedWidget() {
+    return SwitchListTile(
+      value: settings.digital,
+      onChanged: (newValue) => setState(() {
+        settings.digital = newValue;
+      }),
+      secondary: SvgPicture.asset('assets/numeric.svg'),
+      tileColor: sliderColor,
+      activeColor: sliderColor,
+      activeTrackColor: Colors.grey,
+      inactiveTrackColor: Colors.grey,
+      dense: false,
+      controlAffinity: ListTileControlAffinity.trailing,
+    );
+  }
+
+  Widget analogSpeedWidget() {
+    return SwitchListTile(
+      value: settings.analog,
+      onChanged: (newValue) => setState(() {
+        settings.analog = newValue;
+      }),
+      secondary: SvgPicture.asset('assets/wiper.svg', color: Colors.red),
+      tileColor: sliderColor,
+      activeColor: sliderColor,
+      activeTrackColor: Colors.grey,
+      inactiveTrackColor: Colors.grey,
+      dense: false,
+      controlAffinity: ListTileControlAffinity.trailing,
+    );
+  }
+
+  Widget maxSpeedEditWidget(Widget actionWidget) {
+    return Padding(
+        padding: EdgeInsets.only(left: 16.0, right: 24.0),
+        child: Row(
+          children: [
+            SvgPicture.asset('assets/max-speed.svg',
+                width: iconSize, height: iconSize, color: Colors.red),
+            Spacer(),
+            Text(
+              "Max Speed",
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            SizedBox(
+                width: iconSize * 2, height: iconSize * 2, child: actionWidget),
+            Text(
+              settings.metric ? "km/h" : "MPH",
+              style: TextStyle(fontWeight: FontWeight.bold),
+            )
+          ],
+        ));
+  }
+
+  void showEditPopup(BuildContext context) {
+    var popup = SimpleDialog(
+      children: [
+        maxSpeedEditWidget(
+          TextField(
+            decoration: new InputDecoration(
+                labelText: settings.maxSpeed.toString(),
+                contentPadding: EdgeInsets.only(left: 12.0, right: 12.0)),
+            keyboardType: TextInputType.number,
+            inputFormatters: [
+              FilteringTextInputFormatter.digitsOnly,
+            ], // Only numbers can be entered
+            onChanged: (newValue) => setState(() {
+              settings.maxSpeed = int.parse(newValue);
+            }),
+          ),
+        )
+      ],
+    );
+    showDialog(context: context, builder: (context) => popup);
+  }
+
+  Widget maxSpeedWidget() {
+    if (settings.analog) {
+      return maxSpeedEditWidget(TextButton(
+        autofocus: true,
+        child: Text(settings.maxSpeed.toString()),
+        onPressed: () => showEditPopup(context),
+      ));
+    } else {
+      return Row(children: [
+        Padding(
+          padding: EdgeInsets.all(iconSize.toDouble()),
+        )
+      ]);
+    }
+  }
+
+  Widget topSpeedWidget() {
+    return SwitchListTile(
+      value: settings.showTopSpeed,
+      onChanged: (newValue) => setState(() {
+        settings.showTopSpeed = newValue;
+      }),
+      secondary: SvgPicture.asset(
+        'assets/car-cruise-control.svg',
+        color: Colors.green,
+      ),
+      tileColor: sliderColor,
+      activeColor: sliderColor,
+      activeTrackColor: Colors.grey,
+      inactiveTrackColor: Colors.grey,
+      dense: false,
+      controlAffinity: ListTileControlAffinity.trailing,
+    );
+  }
+
+  Widget aboutWidget() {
+    return AboutListTile(
+      applicationIcon: SvgPicture.asset(
+        'assets/icon.svg',
+        width: iconSize * 2,
+        height: iconSize * 2,
+      ),
+      applicationName: 'SPDO',
+      applicationVersion:
+          "${packageInfo?.version} build:${packageInfo?.buildNumber}",
+      aboutBoxChildren: [
+        Center(
+          child: Text("It's a speedometer."),
+        ),
+      ],
+    );
+  }
+
+  @override
+  void dispose() {
+    settings.writePreferences();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Wait until we've actually finished loading everything we need.
+    if (packageInfo == null) {
+      return Column();
+    }
+
+    return Drawer(
+      child: ListView(
+        keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+        children: [
+          backgroundChooserWidget(),
+          unitSelectionWidget(),
+          digitalSpeedWidget(),
+          analogSpeedWidget(),
+          maxSpeedWidget(),
+          topSpeedWidget(),
+          aboutWidget(),
+        ],
+      ),
+    );
+  }
+}
+
+Widget settingsDrawerDisclosureIconButtonWidget(BuildContext context) {
+  return Positioned(
+      bottom: 0.0,
+      left: 0.0,
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: new IconButton(
+          icon: Icon(
+            Icons.settings,
+            color: Colors.black12,
+          ),
+          onPressed: () => Scaffold.of(context).openDrawer(),
+        ),
+      ));
+}

--- a/lib/drawer_widget.dart
+++ b/lib/drawer_widget.dart
@@ -216,15 +216,22 @@ class _DrawerWidgetState extends State<DrawerWidget> {
     }
 
     return Drawer(
-      child: ListView(
-        keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+      child: Column(
         children: [
-          backgroundChooserWidget(),
-          unitSelectionWidget(),
-          digitalSpeedWidget(),
-          analogSpeedWidget(),
-          maxSpeedWidget(),
-          topSpeedWidget(),
+          Expanded(
+            child: ListView(
+              keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+              children: [
+                backgroundChooserWidget(),
+                unitSelectionWidget(),
+                digitalSpeedWidget(),
+                analogSpeedWidget(),
+                maxSpeedWidget(),
+                topSpeedWidget(),
+              ],
+            ),
+          ),
+          Spacer(),
           aboutWidget(),
         ],
       ),

--- a/lib/image_picker_utils.dart
+++ b/lib/image_picker_utils.dart
@@ -15,11 +15,16 @@ class ImagePickerUtils {
     if (!directory.existsSync()) {
       return null;
     }
-    var list = directory.listSync();
-    if (list.isEmpty) {
+    try {
+      var list = directory.listSync();
+      if (list.isEmpty) {
+        return null;
+      } else {
+        return File(list.first.path);
+      }
+    } catch (e) {
+      print(e);
       return null;
-    } else {
-      return File(list.first.path);
     }
   }
 

--- a/lib/settings.dart
+++ b/lib/settings.dart
@@ -1,0 +1,50 @@
+import 'dart:async';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class Settings {
+  static const _DEFAULT_MAX_SPEED = 35;
+  Settings({
+    this.metric = false,
+    this.digital = true,
+    this.analog = true,
+    this.maxSpeed = _DEFAULT_MAX_SPEED,
+    this.showTopSpeed = false,
+  });
+  bool metric;
+  bool digital;
+  bool analog;
+  int maxSpeed;
+  bool showTopSpeed;
+
+  static Settings? _instance;
+  static Future<void> _loadPreferences() async {
+    if (_instance == null) {
+      SharedPreferences prefs = await SharedPreferences.getInstance();
+      _instance = Settings(
+        metric: prefs.getBool('unitsMetric') ?? false,
+        digital: prefs.getBool('showDigital') ?? true,
+        analog: prefs.getBool('showAnalog') ?? true,
+        maxSpeed: prefs.getInt('maxSpeed') ?? _DEFAULT_MAX_SPEED,
+        showTopSpeed: prefs.getBool('showTopSpeed') ?? false,
+      );
+    }
+  }
+
+  static Future<Settings> getInstance() async {
+    await Settings._loadPreferences();
+    if (_instance != null) {
+      return _instance!;
+    }
+    throw new Exception('Settings not initialized');
+  }
+
+  static void writePreferences() async {
+    var instance = await getInstance();
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    prefs.setBool('unitsMetric', instance.metric);
+    prefs.setBool('showDigital', instance.digital);
+    prefs.setBool('showAnalog', instance.analog);
+    prefs.setInt('maxSpeed', instance.maxSpeed);
+    prefs.setBool('showTopSpeed', instance.showTopSpeed);
+  }
+}


### PR DESCRIPTION
Closes #16 

### Pros:
 - [x] This PR includes a hefty refactor of the way the Drawer widget interacts with the speedometer widget.
 - [x] Moved all settings into their own file.
 - [x] Moved Drawer into its own file.
 - [x] Collapsed the Widget hierarchy to only be a couple of widgets total.

### Cons:
 - [x] Had to do some questionable stuff around async initialization in the main speedometer's `Widget build(context)` method.

### Screen Shot:
![IMG_A8AE1EE277AF-1](https://user-images.githubusercontent.com/578572/128471524-e5f10ec8-4125-44f1-8746-e04ee3e5f246.jpeg)
